### PR TITLE
[Feat] FastAPI연동 및 AI퀴즈 생성 API구현

### DIFF
--- a/src/main/java/com/newconomy/global/config/WebClientConfig.java
+++ b/src/main/java/com/newconomy/global/config/WebClientConfig.java
@@ -1,0 +1,29 @@
+package com.newconomy.global.config;
+
+import io.netty.channel.ChannelOption;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.awt.*;
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient fastapiWebClient(){
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(Duration.ofSeconds(15));
+        return WebClient.builder()
+                .baseUrl("http://localhost:8000")
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/com/newconomy/quiz/controller/QuizController.java
+++ b/src/main/java/com/newconomy/quiz/controller/QuizController.java
@@ -1,0 +1,27 @@
+package com.newconomy.quiz.controller;
+
+import com.newconomy.global.response.ApiResponse;
+import com.newconomy.quiz.domain.Quiz;
+import com.newconomy.quiz.dto.QuizRequestDTO;
+import com.newconomy.quiz.service.QuizGenerateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/quiz")
+public class QuizController {
+
+    private final QuizGenerateService quizGenerateService;
+
+    @PostMapping("/generate/{newsId}")
+    public ApiResponse<String> generateQuiz(@PathVariable("newsId") Long newsId) {
+        quizGenerateService.generateQuiz(newsId);
+        return ApiResponse.onSuccess("퀴즈가 성공적으로 만들어졌습니다");
+    }
+}

--- a/src/main/java/com/newconomy/quiz/converter/QuizConverter.java
+++ b/src/main/java/com/newconomy/quiz/converter/QuizConverter.java
@@ -1,0 +1,42 @@
+package com.newconomy.quiz.converter;
+
+import com.newconomy.quiz.domain.Quiz;
+import com.newconomy.quiz.domain.QuizOption;
+import com.newconomy.quiz.dto.QuizRequestDTO;
+import com.newconomy.quiz.dto.QuizResponseDTO;
+import com.newconomy.quiz.enums.QuizType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QuizConverter {
+    public static Quiz toQuizEntity(QuizResponseDTO.QuizGenerateResponseDTO dto) {
+        Quiz quiz = Quiz.builder()
+                .quizType(QuizType.valueOf(dto.getQuizType()))
+                .question(dto.getQuestion())
+                .correctAnswer(dto.getCorrectAnswer())
+                .explanation(dto.getExplanation())
+                .difficultyLevel(dto.getDifficultyLevel())
+                .quizOptionList(new ArrayList<>()) // 가변 리스트로 초기화
+                .build();
+
+        // 옵션 변환 및 연관관계 설정
+        if (dto.getQuizOptionList() != null) {
+            List<QuizOption> options = dto.getQuizOptionList().stream()
+                    .map(optionDto -> toQuizOptionEntity(optionDto, quiz))
+                    .toList();
+            quiz.getQuizOptionList().addAll(options);
+        }
+
+        return quiz;
+    }
+
+    public static QuizOption toQuizOptionEntity(QuizResponseDTO.QuizOptionResposneDTO dto, Quiz quiz) {
+        return QuizOption.builder()
+                .optionText(dto.getOptionText())
+                .optionOrder(dto.getOptionOrder())
+                .isCorrect(dto.isCorrect())
+                .quiz(quiz) // 부모 엔티티 참조 설정 (FK)
+                .build();
+    }
+}

--- a/src/main/java/com/newconomy/quiz/dto/QuizRequestDTO.java
+++ b/src/main/java/com/newconomy/quiz/dto/QuizRequestDTO.java
@@ -1,0 +1,18 @@
+package com.newconomy.quiz.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class QuizRequestDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuizRequestDto{
+        Long newsId;
+        String content;
+    }
+}

--- a/src/main/java/com/newconomy/quiz/dto/QuizResponseDTO.java
+++ b/src/main/java/com/newconomy/quiz/dto/QuizResponseDTO.java
@@ -18,16 +18,28 @@ public class QuizResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class QuizResponseDto{
+    public static class QuizListResponseDto{
+        List<QuizGenerateResponseDTO> quizList;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuizGenerateResponseDTO{
         String quizType;
         String question;
         String correctAnswer;
         String explanation;
         int difficultyLevel;
-        List<QuizOptionResposneDto> quizOptionList;
+        List<QuizOptionResposneDTO> quizOptionList;
     }
 
-    public static class QuizOptionResposneDto{
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuizOptionResposneDTO{
         String optionText;
         int optionOrder;
         boolean isCorrect;

--- a/src/main/java/com/newconomy/quiz/dto/QuizResponseDTO.java
+++ b/src/main/java/com/newconomy/quiz/dto/QuizResponseDTO.java
@@ -1,5 +1,6 @@
 package com.newconomy.quiz.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.newconomy.quiz.domain.QuizOption;
 import com.newconomy.quiz.enums.QuizType;
 import jakarta.persistence.*;
@@ -42,6 +43,7 @@ public class QuizResponseDTO {
     public static class QuizOptionResposneDTO{
         String optionText;
         int optionOrder;
+        @JsonProperty("isCorrect")
         boolean isCorrect;
     }
 }

--- a/src/main/java/com/newconomy/quiz/dto/QuizResponseDTO.java
+++ b/src/main/java/com/newconomy/quiz/dto/QuizResponseDTO.java
@@ -1,0 +1,35 @@
+package com.newconomy.quiz.dto;
+
+import com.newconomy.quiz.domain.QuizOption;
+import com.newconomy.quiz.enums.QuizType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QuizResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuizResponseDto{
+        String quizType;
+        String question;
+        String correctAnswer;
+        String explanation;
+        int difficultyLevel;
+        List<QuizOptionResposneDto> quizOptionList;
+    }
+
+    public static class QuizOptionResposneDto{
+        String optionText;
+        int optionOrder;
+        boolean isCorrect;
+    }
+}

--- a/src/main/java/com/newconomy/quiz/repository/QuizRepository.java
+++ b/src/main/java/com/newconomy/quiz/repository/QuizRepository.java
@@ -1,0 +1,8 @@
+package com.newconomy.quiz.repository;
+
+import com.newconomy.quiz.domain.Quiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+
+}

--- a/src/main/java/com/newconomy/quiz/service/QuizGenerateService.java
+++ b/src/main/java/com/newconomy/quiz/service/QuizGenerateService.java
@@ -1,4 +1,45 @@
 package com.newconomy.quiz.service;
 
+import com.newconomy.news.domain.News;
+import com.newconomy.news.repository.NewsRepository;
+import com.newconomy.quiz.converter.QuizConverter;
+import com.newconomy.quiz.domain.Quiz;
+import com.newconomy.quiz.dto.QuizRequestDTO;
+import com.newconomy.quiz.dto.QuizResponseDTO;
+import com.newconomy.quiz.repository.QuizRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class QuizGenerateService {
+
+    private final QuizRepository quizRepository;
+    private final NewsRepository newsRepository;
+    private final WebClient webClient;
+
+    public void generateQuiz(Long newsId) {
+        News news = newsRepository.findById(newsId).orElseThrow(() ->
+                new EntityNotFoundException("뉴스를 찾을 수 없습니다"));
+
+        QuizResponseDTO.QuizListResponseDto responseDto = webClient.post()
+                .uri("/api/quiz/generate")
+                .bodyValue(new QuizRequestDTO.QuizRequestDto(news.getId(), news.getContent()))
+                .retrieve()
+                .bodyToMono(QuizResponseDTO.QuizListResponseDto.class)
+                .block();
+
+        List<QuizResponseDTO.QuizGenerateResponseDTO> quizList = responseDto.getQuizList();
+        List<Quiz> quizzes = quizList.stream().map(QuizConverter::toQuizEntity)
+                .toList();
+        quizRepository.saveAll(quizzes);
+        log.info("뉴스 ID {}로부터 {}개의 퀴즈가 성공적으로 생성 및 저장되었습니다.", newsId, quizzes.size());    }
 }

--- a/src/main/java/com/newconomy/quiz/service/QuizGenerateService.java
+++ b/src/main/java/com/newconomy/quiz/service/QuizGenerateService.java
@@ -1,0 +1,4 @@
+package com.newconomy.quiz.service;
+
+public class QuizGenerateService {
+}

--- a/src/main/java/com/newconomy/quiz/service/QuizGenerateService.java
+++ b/src/main/java/com/newconomy/quiz/service/QuizGenerateService.java
@@ -32,7 +32,7 @@ public class QuizGenerateService {
 
         QuizResponseDTO.QuizListResponseDto responseDto = webClient.post()
                 .uri("/api/quiz/generate")
-                .bodyValue(new QuizRequestDTO.QuizRequestDto(news.getId(), news.getContent()))
+                .bodyValue(new QuizRequestDTO.QuizRequestDto(news.getId(), news.getFullContent()))
                 .retrieve()
                 .bodyToMono(QuizResponseDTO.QuizListResponseDto.class)
                 .block();


### PR DESCRIPTION
## 📌 요약
- FastAPI서버의 AI퀴즈 생성 및 저장 API와 연동
- WebClientConfig 설정 추가
- build.gradle 의존성 추가

## ✨ 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 설정 변경

## 🧪 테스트
- [ ] 로컬 테스트
- [x] API 호출 확인
- [x] Spring ↔ FastAPI 연동

## ⚠️ 참고 사항
- 리뷰 시 주의할 점 / 배포 영향

## 🔗 관련 이슈
- closes #
