### PR TITLE
[Feat] 경제 용어 기반 퀴즈 생성(FastAPI연동)

### DIFF
--- a/src/main/java/com/newconomy/quiz/controller/QuizController.java
+++ b/src/main/java/com/newconomy/quiz/controller/QuizController.java
@@ -25,28 +25,19 @@ public class QuizController {
     private final QuizGenerateService quizGenerateService;
     private final QuizService quizService;
 
-    @Operation(summary = "해당 뉴스의 퀴즈 생성", description = "퀴즈 생성 API, fastapi서버의 upstage api를 호출합니다 / QuizId를 List로 반환")
+    @Operation(summary = "해당 뉴스의 퀴즈 생성", description = "퀴즈 생성 API, fastapi서버의 upstage api를 호출합니다")
     @PostMapping("/generate/{newsId}")
     public ApiResponse<List<QuizResponseDTO.QuizGenerateResponseDTO>> generateQuiz(@PathVariable("newsId") Long newsId) {
         List<QuizResponseDTO.QuizGenerateResponseDTO> quizzes = quizGenerateService.generateQuiz(newsId);
         return ApiResponse.onSuccess(quizzes);
     }
 
-//    @Operation(summary = "퀴즈 목록 조회")
-//    @GetMapping("/quiz")
-//    public ApiResponse<Page<QuizResponseDTO.QuizGenerateResponseDTO>> getQuizzes(@RequestParam(defaultValue = "0") int page,
-//                                                                                 @RequestParam(defaultValue = "10") int size
-//    ) {
-//        Pageable pageable = PageRequest.of(page,size, Sort.by("createdAt").descending());
-//        return ApiResponse.onSuccess(quizService.getQuizzes(pageable));
-//    }
-
-//    @Operation(summary = "퀴즈 상세 조회")
-//    @GetMapping("/quiz/{quizId}")
-//    public ApiResponse<Object> getQuiz(@PathVariable Long quizId) {
-//        // return ApiResponse.onSuccess(quizService.getQuiz(quizId));
-//        return ApiResponse.onSuccess("퀴즈 상세 조회: " + quizId);
-//    }
+    @Operation(summary = "경제 용어 기반 퀴즈 생성", description = "경제 용어 기반 퀴즈 생성 API, fastapi서버의 upstage api를 호출합니다")
+    @PostMapping("/generateByTerm")
+    public ApiResponse<List<QuizResponseDTO.QuizGenerateResponseDTO>> generateQuizByTerm(){
+        List<QuizResponseDTO.QuizGenerateResponseDTO> quizzes = quizGenerateService.generateQuizByTerm();
+        return ApiResponse.onSuccess(quizzes);
+    }
 
     @Operation(summary = "퀴즈 답안 제출")
     @PostMapping("/{quizId}/submit")

--- a/src/main/java/com/newconomy/quiz/converter/QuizConverter.java
+++ b/src/main/java/com/newconomy/quiz/converter/QuizConverter.java
@@ -3,8 +3,10 @@ package com.newconomy.quiz.converter;
 import com.newconomy.quiz.domain.Quiz;
 import com.newconomy.quiz.domain.QuizAttempt;
 import com.newconomy.quiz.domain.QuizOption;
+import com.newconomy.quiz.dto.QuizRequestDTO;
 import com.newconomy.quiz.dto.QuizResponseDTO;
 import com.newconomy.quiz.enums.QuizType;
+import com.newconomy.term.domain.Term;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,6 +71,15 @@ public class QuizConverter {
                 .explanation(quiz.getExplanation())
                 .isCorrect(quizAttempt.isCorrect())
                 .memberAnswer(quizAttempt.getMemberAnswer())
+                .build();
+    }
+
+    public static QuizRequestDTO.QuizGenerateByTermRequestDTO toQuizGenerateByTermDTO(Term term){
+        return QuizRequestDTO.QuizGenerateByTermRequestDTO.builder()
+                .termId(term.getId())
+                .termName(term.getTermName())
+                .simpleExplanation(term.getSimpleExplanation())
+                .detailedExplanation(term.getDetailedExplanation())
                 .build();
     }
 }

--- a/src/main/java/com/newconomy/quiz/dto/QuizRequestDTO.java
+++ b/src/main/java/com/newconomy/quiz/dto/QuizRequestDTO.java
@@ -27,4 +27,16 @@ public class QuizRequestDTO {
         @NotNull
         String memberAnswer;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "경제 용어 기반 퀴즈 생성 요청 DTO")
+    public static class QuizGenerateByTermRequestDTO{
+        Long termId;
+        String termName;
+        String simpleExplanation;
+        String detailedExplanation;
+    }
 }

--- a/src/main/java/com/newconomy/quiz/service/QuizGenerateService.java
+++ b/src/main/java/com/newconomy/quiz/service/QuizGenerateService.java
@@ -7,6 +7,8 @@ import com.newconomy.quiz.domain.Quiz;
 import com.newconomy.quiz.dto.QuizRequestDTO;
 import com.newconomy.quiz.dto.QuizResponseDTO;
 import com.newconomy.quiz.repository.QuizRepository;
+import com.newconomy.term.domain.Term;
+import com.newconomy.term.repository.TermRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -26,6 +29,7 @@ public class QuizGenerateService {
 
     private final QuizRepository quizRepository;
     private final NewsRepository newsRepository;
+    private final TermRepository termRepository;
     private final WebClient webClient;
 
     public List<QuizResponseDTO.QuizGenerateResponseDTO> generateQuiz(Long newsId) {
@@ -49,5 +53,36 @@ public class QuizGenerateService {
         List<QuizResponseDTO.QuizGenerateResponseDTO> result = saved.stream().map(QuizConverter::toQuizDTO).toList();
         log.info("뉴스 ID {}로부터 {}개의 퀴즈가 성공적으로 생성 및 저장되었습니다.", newsId, saved.size());
         return result;
+    }
+    
+    public List<QuizResponseDTO.QuizGenerateResponseDTO> generateQuizByTerm(){
+        List<Term> allTerms = termRepository.findAll();
+        List<QuizRequestDTO.QuizGenerateByTermRequestDTO> requestDTO = allTerms.stream().
+                map(QuizConverter::toQuizGenerateByTermDTO).toList();
+
+        Map<String, Object> requestBody = Map.of("terms",requestDTO);
+        QuizResponseDTO.QuizListResponseDto responseDTO = webClient.post()
+                .uri("/api/quiz/generate/terms")
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(QuizResponseDTO.QuizListResponseDto.class)
+                .block();
+
+        if (responseDTO == null || responseDTO.getQuizList() == null) {
+            throw new RuntimeException("AI 서버로부터 퀴즈를 받아오지 못했습니다.");
+        }
+
+        List<QuizResponseDTO.QuizGenerateResponseDTO> quizList = responseDTO.getQuizList();
+
+        // 받아온 퀴즈를 DB에 저장
+        List<Quiz> saved = quizRepository.saveAll(
+                quizList.stream()
+                        .map(QuizConverter::toQuizEntity)
+                        .toList()
+        );
+
+        return saved.stream()
+                .map(QuizConverter::toQuizDTO)
+                .toList();
     }
 }


### PR DESCRIPTION
## 📌 요약
- DB에 저장된 경제 용어 리스트를 FastAPI서버로 전달하여 경제 용어 기반 퀴즈 생성
## ✨ 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정 변경

## 🧪 테스트
- [ ] 로컬 테스트
- [x] API 호출 확인
- [x] Spring ↔ FastAPI 연동

## ⚠️ 참고 사항
- 리뷰 시 주의할 점 / 배포 영향

## 🔗 관련 이슈
- closes #
