### PR TITLE
Fix/crawl full content

### DIFF
--- a/src/main/java/com/newconomy/news/controller/NewsController.java
+++ b/src/main/java/com/newconomy/news/controller/NewsController.java
@@ -37,7 +37,7 @@ public class NewsController {
     public ApiResponse<NewsResponseDTO.NewsListViewDTO> viewAllNews(
             @RequestParam(value = "newsCategory", required = false) String category,
             @RequestParam(value = "page", defaultValue = "0") int page,
-            @RequestParam(value = "size", defaultValue = "10") int size
+            @RequestParam(value = "size", defaultValue = "12") int size
     ) {
         // 뉴스 카테고리 필터링이 들어왔는지 확인
         NewsCategory newsCategory = category != null

--- a/src/main/java/com/newconomy/news/crawling/SearchService.java
+++ b/src/main/java/com/newconomy/news/crawling/SearchService.java
@@ -61,7 +61,7 @@ public class SearchService {
 
         // 비동기로 뉴스 기사 원문 크롤링 및 경제 용어 추출
         newsList.forEach(
-                news -> newsCrawlingService.crawlFullContent(news.getId())
+                news -> newsCrawlingService.crawlFullContent(news.getId(), news.getUrl())
         );
         return newsItemsResponseDTO;
     }

--- a/src/main/java/com/newconomy/news/service/NewsService.java
+++ b/src/main/java/com/newconomy/news/service/NewsService.java
@@ -141,7 +141,7 @@ public class NewsService {
 
             // 비동기로 각 기사의 원문 크롤링
             newsList.forEach(
-                    news -> newsCrawlingService.crawlFullContent(news.getId())
+                    news -> newsCrawlingService.crawlFullContent(news.getId(), news.getUrl())
             );
 
         } catch (Exception e) {


### PR DESCRIPTION
## 📌 요약
- 비동기로 뉴스 원문 크롤링 시 일부 뉴스는 크롤링이 되지 않던 현상 해결.
- 문제 원인 : 메인 스레드가 커밋하기도 전에 비동기 크롤링 메서드(스레드)를 실행하자마자 news 엔티티를 DB에서 가져오려고 해서 race condition 발생
- 해결 방법 : 비동기 크롤링 메서드의 파라미터로 뉴스 기사 원문의 url을 전달해서 비동기 스레드는 크롤링부터 한 뒤에 크롤링한 데이터를 news 엔티티에 저장하려고 할 때 DB 접근시킴. (비동기 스레드가 크롤링 하는 시간 동안 메인 스레드가 먼저 커밋하므로 race condition 발생하지 않음)

## ✨ 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정 변경

## 🧪 테스트
- [x] 로컬 테스트
- [x] API 호출 확인
- [ ] Spring ↔ FastAPI 연동

## ⚠️ 참고 사항
- 리뷰 시 주의할 점 / 배포 영향

## 🔗 관련 이슈
- closes #
