### PR TITLE
[Refactor] 뉴스/용어 기반 퀴즈 생성API 비동기로 수정

### DIFF
--- a/src/main/java/com/newconomy/quiz/controller/QuizController.java
+++ b/src/main/java/com/newconomy/quiz/controller/QuizController.java
@@ -29,16 +29,16 @@ public class QuizController {
 
     @Operation(summary = "해당 뉴스의 퀴즈 생성", description = "퀴즈 생성 API, fastapi서버의 upstage api를 호출합니다")
     @PostMapping("/generate/{newsId}")
-    public ApiResponse<List<QuizResponseDTO.QuizGenerateResponseDTO>> generateQuiz(@PathVariable("newsId") Long newsId) {
-        List<QuizResponseDTO.QuizGenerateResponseDTO> quizzes = quizGenerateService.generateQuiz(newsId);
-        return ApiResponse.onSuccess(quizzes);
+    public ApiResponse<String> generateQuiz(@PathVariable("newsId") Long newsId) {
+        quizGenerateService.generateQuiz(newsId);
+        return ApiResponse.onSuccess("해당 뉴스의 퀴즈 생성이 시작되었습니다");
     }
 
-    @Operation(summary = "경제 용어 기반 퀴즈 생성", description = "경제 용어 기반 퀴즈 생성 API, fastapi서버의 upstage api를 호출합니다")
-    @PostMapping("/generateByTerm")
-    public ApiResponse<List<QuizResponseDTO.QuizGenerateResponseDTO>> generateQuizByTerm(){
-        List<QuizResponseDTO.QuizGenerateResponseDTO> quizzes = quizGenerateService.generateQuizByTerm();
-        return ApiResponse.onSuccess(quizzes);
+    @Operation(summary = "해당 뉴스의 퀴즈 조회", description = "퀴즈 조회 API, 해당 뉴스의 퀴즈 list를 조회합니다")
+    @GetMapping("/{newsId}")
+    public ApiResponse<List<QuizResponseDTO.QuizGenerateResponseDTO>> getQuizzesWithNews(@PathVariable("newsId") Long newsId) {
+        List<QuizResponseDTO.QuizGenerateResponseDTO> quizzesWithNews = quizService.getQuizzesWithNews(newsId);
+        return ApiResponse.onSuccess(quizzesWithNews);
     }
 
     @Operation(summary = "퀴즈 답안 제출")

--- a/src/main/java/com/newconomy/quiz/controller/QuizController.java
+++ b/src/main/java/com/newconomy/quiz/controller/QuizController.java
@@ -17,6 +17,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Random;
+import java.util.UUID;
 
 @Tag(name = "퀴즈 컨트롤러")
 @RestController
@@ -35,10 +37,24 @@ public class QuizController {
     }
 
     @Operation(summary = "해당 뉴스의 퀴즈 조회", description = "퀴즈 조회 API, 해당 뉴스의 퀴즈 list를 조회합니다")
-    @GetMapping("/{newsId}")
+    @GetMapping("/news/{newsId}")
     public ApiResponse<List<QuizResponseDTO.QuizGenerateResponseDTO>> getQuizzesWithNews(@PathVariable("newsId") Long newsId) {
         List<QuizResponseDTO.QuizGenerateResponseDTO> quizzesWithNews = quizService.getQuizzesWithNews(newsId);
         return ApiResponse.onSuccess(quizzesWithNews);
+    }
+
+    @Operation(summary = "경제 용어 기반 퀴즈 생성", description = "경제 용어 기반 퀴즈 생성 API, fastapi서버의 upstage api를 호출합니다")
+    @PostMapping("/generateByTerm")
+    public ApiResponse<String> generateQuiz() {
+        String batchId = UUID.randomUUID().toString();
+        quizGenerateService.generateQuizByTerm(batchId);
+        return ApiResponse.onSuccess("경제 용어 기반 퀴즈 생성이 시작되었습니다, batchId:" + batchId);
+    }
+
+    @GetMapping("/term/{batchId}")
+    public ApiResponse<List<QuizResponseDTO.QuizGenerateResponseDTO>> getQuizzesWithTerms(@PathVariable("batchId") String batchId) {
+        List<QuizResponseDTO.QuizGenerateResponseDTO> quizzesWithTerms = quizService.getQuizzesWithTerms(batchId);
+        return ApiResponse.onSuccess(quizzesWithTerms);
     }
 
     @Operation(summary = "퀴즈 답안 제출")

--- a/src/main/java/com/newconomy/quiz/converter/QuizConverter.java
+++ b/src/main/java/com/newconomy/quiz/converter/QuizConverter.java
@@ -1,5 +1,6 @@
 package com.newconomy.quiz.converter;
 
+import com.newconomy.news.domain.News;
 import com.newconomy.quiz.domain.Quiz;
 import com.newconomy.quiz.domain.QuizAttempt;
 import com.newconomy.quiz.domain.QuizOption;
@@ -12,8 +13,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class QuizConverter {
-    public static Quiz toQuizEntity(QuizResponseDTO.QuizGenerateResponseDTO dto) {
+    public static Quiz toQuizEntity(QuizResponseDTO.QuizGenerateResponseDTO dto, News news, Term term) {
         Quiz quiz = Quiz.builder()
+                .news(news)
+                .term(term)
                 .quizType(QuizType.valueOf(dto.getQuizType()))
                 .question(dto.getQuestion())
                 .correctAnswer(dto.getCorrectAnswer())

--- a/src/main/java/com/newconomy/quiz/converter/QuizConverter.java
+++ b/src/main/java/com/newconomy/quiz/converter/QuizConverter.java
@@ -13,10 +13,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class QuizConverter {
-    public static Quiz toQuizEntity(QuizResponseDTO.QuizGenerateResponseDTO dto, News news, Term term) {
+    public static Quiz toQuizEntity(QuizResponseDTO.QuizGenerateResponseDTO dto, News news, String batchId) {
         Quiz quiz = Quiz.builder()
                 .news(news)
-                .term(term)
+                .batchId(batchId)
                 .quizType(QuizType.valueOf(dto.getQuizType()))
                 .question(dto.getQuestion())
                 .correctAnswer(dto.getCorrectAnswer())

--- a/src/main/java/com/newconomy/quiz/domain/Quiz.java
+++ b/src/main/java/com/newconomy/quiz/domain/Quiz.java
@@ -25,10 +25,6 @@ public class Quiz extends BaseEntity {
     @JoinColumn(name = "news_id")
     private News news;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "term_id")
-    private Term term;
-
     @Enumerated(value = EnumType.STRING)
     private QuizType quizType;
 
@@ -41,6 +37,8 @@ public class Quiz extends BaseEntity {
 
     private String explanation;
     private int difficultyLevel;
+
+    private String batchId; //용어 퀴즈 생성 후 묶음 조회를 위해
 
     @Builder.Default
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/newconomy/quiz/domain/Quiz.java
+++ b/src/main/java/com/newconomy/quiz/domain/Quiz.java
@@ -1,7 +1,9 @@
 package com.newconomy.quiz.domain;
 
 import com.newconomy.global.common.BaseEntity;
+import com.newconomy.news.domain.News;
 import com.newconomy.quiz.enums.QuizType;
+import com.newconomy.term.domain.Term;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
@@ -19,6 +21,14 @@ public class Quiz extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id")
+    private News news;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id")
+    private Term term;
+
     @Enumerated(value = EnumType.STRING)
     private QuizType quizType;
 
@@ -35,4 +45,6 @@ public class Quiz extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<QuizOption> quizOptionList = new ArrayList<>();
+
+
 }

--- a/src/main/java/com/newconomy/quiz/repository/QuizRepository.java
+++ b/src/main/java/com/newconomy/quiz/repository/QuizRepository.java
@@ -2,7 +2,14 @@ package com.newconomy.quiz.repository;
 
 import com.newconomy.quiz.domain.Quiz;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
+    @Query("select q from Quiz q left join fetch q.quizOptionList where q.news.id = :newsId")
+    List<Quiz> findByNewsId(@Param("newsId") Long newsId);
 
+    boolean existsByNewsId(Long newsId);
 }

--- a/src/main/java/com/newconomy/quiz/repository/QuizRepository.java
+++ b/src/main/java/com/newconomy/quiz/repository/QuizRepository.java
@@ -11,5 +11,8 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
     @Query("select q from Quiz q left join fetch q.quizOptionList where q.news.id = :newsId")
     List<Quiz> findByNewsId(@Param("newsId") Long newsId);
 
+    @Query("select q from Quiz q left join fetch q.quizOptionList where q.batchId = :batchId")
+    List<Quiz> findByBatchId(@Param("batchId") String batchId);
+
     boolean existsByNewsId(Long newsId);
 }

--- a/src/main/java/com/newconomy/quiz/service/QuizGenerateService.java
+++ b/src/main/java/com/newconomy/quiz/service/QuizGenerateService.java
@@ -12,6 +12,7 @@ import com.newconomy.term.repository.TermRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -30,29 +31,32 @@ public class QuizGenerateService {
     private final QuizRepository quizRepository;
     private final NewsRepository newsRepository;
     private final TermRepository termRepository;
+    private final QuizService quizService;
     private final WebClient webClient;
 
-    public List<QuizResponseDTO.QuizGenerateResponseDTO> generateQuiz(Long newsId) {
+    @Async
+    public void generateQuiz(Long newsId) {
+
+        if(quizRepository.existsByNewsId(newsId)){
+            return;
+        }
+
         News news = newsRepository.findById(newsId).orElseThrow(() ->
                 new EntityNotFoundException("뉴스를 찾을 수 없습니다"));
 
-        QuizResponseDTO.QuizListResponseDto responseDto = webClient.post()
+        webClient.post()
                 .uri("/api/quiz/generate")
                 .bodyValue(new QuizRequestDTO.QuizGenerateRequestDTO(news.getId(), news.getFullContent()))
                 .retrieve()
                 .bodyToMono(QuizResponseDTO.QuizListResponseDto.class)
-                .block();
-
-        if (responseDto == null || responseDto.getQuizList() == null) {
-            throw new IllegalStateException("퀴즈 생성 API 응답이 비어 있습니다");
-        }
-
-        List<QuizResponseDTO.QuizGenerateResponseDTO> quizList = responseDto.getQuizList();
-        List<Quiz> saved = quizRepository.saveAll(quizList.stream().map(QuizConverter::toQuizEntity)
-                .toList());
-        List<QuizResponseDTO.QuizGenerateResponseDTO> result = saved.stream().map(QuizConverter::toQuizDTO).toList();
-        log.info("뉴스 ID {}로부터 {}개의 퀴즈가 성공적으로 생성 및 저장되었습니다.", newsId, saved.size());
-        return result;
+                .subscribe(response -> {
+                    if (response != null && response.getQuizList() != null) {
+                        // 별도 서비스의 트랜잭션을 통해 뉴스 연관관계와 함께 저장
+                        quizService.saveQuizzesWithNews(response.getQuizList(), newsId);
+                    }
+                },error -> {
+                    log.error("LLM 호출 중 에러 발생 (뉴스 ID: {}): {}", newsId, error.getMessage());
+                });
     }
     
     public List<QuizResponseDTO.QuizGenerateResponseDTO> generateQuizByTerm(){
@@ -77,7 +81,7 @@ public class QuizGenerateService {
         // 받아온 퀴즈를 DB에 저장
         List<Quiz> saved = quizRepository.saveAll(
                 quizList.stream()
-                        .map(QuizConverter::toQuizEntity)
+                        .map(dto -> QuizConverter.toQuizEntity(dto,null,null))
                         .toList()
         );
 

--- a/src/main/java/com/newconomy/quiz/service/QuizService.java
+++ b/src/main/java/com/newconomy/quiz/service/QuizService.java
@@ -50,6 +50,11 @@ public class QuizService {
         return quizzes.stream().map(quiz -> QuizConverter.toQuizDTO(quiz)).toList();
     }
 
+    public List<QuizResponseDTO.QuizGenerateResponseDTO> getQuizzesWithTerms(String batchId){
+        List<Quiz> quizzes = quizRepository.findByBatchId(batchId);
+        return quizzes.stream().map(quiz -> QuizConverter.toQuizDTO(quiz)).toList();
+    }
+
     @Transactional
     public QuizResponseDTO.SubmitResultDTO submitAnswer(Long quizId, Long memberId, QuizRequestDTO.SubmitDTO request){
         Member member = memberRepository.findById(memberId).orElseThrow(
@@ -75,6 +80,16 @@ public class QuizService {
         News news = newsRepository.getReferenceById(newsId); //ID만 필요하기 때문
         List<Quiz> entities = quizList.stream()
                 .map(dto -> QuizConverter.toQuizEntity(dto, news, null)).toList();
+        quizRepository.saveAll(entities);
+    }
+
+    @Transactional
+    public void saveQuizzesWithTerms(List<QuizResponseDTO.QuizGenerateResponseDTO> quizList, String batchId) {
+        List<Quiz> entities = quizList.stream()
+                .map(dto -> {
+                    return QuizConverter.toQuizEntity(dto, null, batchId);
+                })
+                .toList();
         quizRepository.saveAll(entities);
     }
 }

--- a/src/main/java/com/newconomy/term/repository/TermRepository.java
+++ b/src/main/java/com/newconomy/term/repository/TermRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import javax.swing.text.html.Option;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,4 +17,8 @@ public interface TermRepository extends JpaRepository<Term, Long> {
     List<Term> searchByKeywordTop10(@Param("keyword") String keyword, Pageable pageable);
 
     Optional<Term> findByTermName(String termName);
+    List<Term> findByTermNameIn(Collection<String> termNames);
+
+    @Query(value = "SELECT * FROM Term ORDER BY RAND() LIMIT 4", nativeQuery = true)
+    List<Term> find4RandomTerms();
 }


### PR DESCRIPTION
## 📌 요약
- 뉴스/용어 기반 퀴즈 생성을 webClient.block()의 동기 방식에서 webClient.subscribe() 비동기로 변경
- Quiz엔티티에 뉴스 기반 퀴즈 조회를 위한News연관관계 추가, 용어 기반 퀴즈 조회를 위한 batchId필드 추가
## ✨ 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정 변경

## 🧪 테스트
- [ ] 로컬 테스트
- [x] API 호출 확인
- [ ] Spring ↔ FastAPI 연동

## ⚠️ 참고 사항
- 리뷰 시 주의할 점 / 배포 영향

## 🔗 관련 이슈
- closes #
